### PR TITLE
Support intelij 2018.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,5 +33,5 @@ tasks.withType<Wrapper> {
 
 intellij {
     pluginName = "requirements"
-    version = "2018.1"
+    version = "2018.2"
 }


### PR DESCRIPTION
Thank you for this essential plugin, it should be included with PyCharm by default!

Tested with:
PyCharm 2018.2.4 (Professional Edition)
Build #PY-182.4505.26, built on September 19, 2018