### PR TITLE
Make plugin not apply to other txt files than requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ PyCharm, and other products if the Python plugin is installed:
 
 ## TODO
 
-* Distinguish a plain text file from file requirements.txt
 * Support all relations
 * Opening local source code
 * Code completion

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
                   order="first"
                   name="requirements.txt"
                   fileNames="requirements.txt"
-                  patterns="*.txt"/>
+                  patterns=""/>
         <localInspection language="requirements.txt"
                          shortName="ReferenceExistsInspection"
                          suppressId="Requirements"


### PR DESCRIPTION
Due to there being a pattern match for all *.txt files, the requirements
language syntax highlighting was applied to files containing f.ex. documentation
as well, causing such files to present red squiggly lines and inconsistent coloring.

If the original behaviour is desired, this can be re-enabled by going to
File > Settings > Editor > File Types > Requirements Language > Registered patterns
and adding a new line containing
*.txt
Similarly, other specific file names that should use the requirements language formatting can be added there.